### PR TITLE
ErrorNotify 메서드 자바 컨벤션에 맞게 수정 및 VO 객체에 Lombok 적용

### DIFF
--- a/Android_example/app/build.gradle
+++ b/Android_example/app/build.gradle
@@ -27,4 +27,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.3.0-alpha01'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-alpha01'
     implementation 'com.google.code.gson:gson:2.8.5'
+    annotationProcessor("org.projectlombok:lombok:1.18.8")
+    compileOnly 'org.projectlombok:lombok:1.18.8'
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/MainActivity.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/MainActivity.java
@@ -108,11 +108,11 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
                 catch (Exception e) {
-                    ErrorNotify(s + "\n" + e.getMessage());
+                    errorNotify(s + "\n" + e.getMessage());
                 }
             }
             else {
-                ErrorNotify(s);
+                errorNotify(s);
             }
         }
     }
@@ -181,8 +181,7 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void ErrorNotify(String errorMessage)
-    {
+    private void errorNotify(String errorMessage) {
         String title = "통신장애";
         String message = "통신이 월활하지 않습니다. 다시 시도하여 주세요.";
 

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccBasicInfoBodyReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccBasicInfoBodyReq.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccBasicInfoBodyReq implements Serializable {
     private String INQ_ACNO;
     private String INQ_BAS_DT;
-
-    public String getINQ_ACNO() {
-        return INQ_ACNO;
-    }
-
-    public void setINQ_ACNO(String INQ_ACNO) {
-        this.INQ_ACNO = INQ_ACNO;
-    }
-
-    public String getINQ_BAS_DT() {
-        return INQ_BAS_DT;
-    }
-
-    public void setINQ_BAS_DT(String INQ_BAS_DT) {
-        this.INQ_BAS_DT = INQ_BAS_DT;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccBasicInfoDataReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccBasicInfoDataReq.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccBasicInfoDataReq implements Serializable {
     private AccBasicInfoHeaderReq dataHeader;
     private AccBasicInfoBodyReq dataBody;
-
-    public AccBasicInfoHeaderReq getDataHeader() {
-        return dataHeader;
-    }
-
-    public void setDataHeader(AccBasicInfoHeaderReq dataHeader) {
-        this.dataHeader = dataHeader;
-    }
-
-    public AccBasicInfoBodyReq getDataBody() {
-        return dataBody;
-    }
-
-    public void setDataBody(AccBasicInfoBodyReq dataBody) {
-        this.dataBody = dataBody;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccBasicInfoHeaderReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccBasicInfoHeaderReq.java
@@ -2,6 +2,13 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccBasicInfoHeaderReq implements Serializable {
     private String UTZPE_CNCT_IPAD;
     private String UTZPE_CNCT_MCHR_UNQ_ID;
@@ -11,68 +18,4 @@ public class AccBasicInfoHeaderReq implements Serializable {
     private String UTZ_MCHR_OS_VER_NM;
     private String UTZ_MCHR_MDL_NM;
     private String UTZ_MCHR_APP_VER_NM;
-
-    public String getUTZPE_CNCT_IPAD() {
-        return UTZPE_CNCT_IPAD;
-    }
-
-    public void setUTZPE_CNCT_IPAD(String UTZPE_CNCT_IPAD) {
-        this.UTZPE_CNCT_IPAD = UTZPE_CNCT_IPAD;
-    }
-
-    public String getUTZPE_CNCT_MCHR_UNQ_ID() {
-        return UTZPE_CNCT_MCHR_UNQ_ID;
-    }
-
-    public void setUTZPE_CNCT_MCHR_UNQ_ID(String UTZPE_CNCT_MCHR_UNQ_ID) {
-        this.UTZPE_CNCT_MCHR_UNQ_ID = UTZPE_CNCT_MCHR_UNQ_ID;
-    }
-
-    public String getUTZPE_CNCT_TEL_NO_TXT() {
-        return UTZPE_CNCT_TEL_NO_TXT;
-    }
-
-    public void setUTZPE_CNCT_TEL_NO_TXT(String UTZPE_CNCT_TEL_NO_TXT) {
-        this.UTZPE_CNCT_TEL_NO_TXT = UTZPE_CNCT_TEL_NO_TXT;
-    }
-
-    public String getUTZPE_CNCT_MCHR_IDF_SRNO() {
-        return UTZPE_CNCT_MCHR_IDF_SRNO;
-    }
-
-    public void setUTZPE_CNCT_MCHR_IDF_SRNO(String UTZPE_CNCT_MCHR_IDF_SRNO) {
-        this.UTZPE_CNCT_MCHR_IDF_SRNO = UTZPE_CNCT_MCHR_IDF_SRNO;
-    }
-
-    public String getUTZ_MCHR_OS_DSCD() {
-        return UTZ_MCHR_OS_DSCD;
-    }
-
-    public void setUTZ_MCHR_OS_DSCD(String UTZ_MCHR_OS_DSCD) {
-        this.UTZ_MCHR_OS_DSCD = UTZ_MCHR_OS_DSCD;
-    }
-
-    public String getUTZ_MCHR_OS_VER_NM() {
-        return UTZ_MCHR_OS_VER_NM;
-    }
-
-    public void setUTZ_MCHR_OS_VER_NM(String UTZ_MCHR_OS_VER_NM) {
-        this.UTZ_MCHR_OS_VER_NM = UTZ_MCHR_OS_VER_NM;
-    }
-
-    public String getUTZ_MCHR_MDL_NM() {
-        return UTZ_MCHR_MDL_NM;
-    }
-
-    public void setUTZ_MCHR_MDL_NM(String UTZ_MCHR_MDL_NM) {
-        this.UTZ_MCHR_MDL_NM = UTZ_MCHR_MDL_NM;
-    }
-
-    public String getUTZ_MCHR_APP_VER_NM() {
-        return UTZ_MCHR_APP_VER_NM;
-    }
-
-    public void setUTZ_MCHR_APP_VER_NM(String UTZ_MCHR_APP_VER_NM) {
-        this.UTZ_MCHR_APP_VER_NM = UTZ_MCHR_APP_VER_NM;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccTransListBodyReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccTransListBodyReq.java
@@ -2,32 +2,15 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListBodyReq implements Serializable {
     private String INQ_ACNO;
     private String INQ_STA_DT;
     private String INQ_END_DT;
-
-    public String getINQ_ACNO() {
-        return INQ_ACNO;
-    }
-
-    public void setINQ_ACNO(String INQ_ACNO) {
-        this.INQ_ACNO = INQ_ACNO;
-    }
-
-    public String getINQ_STA_DT() {
-        return INQ_STA_DT;
-    }
-
-    public void setINQ_STA_DT(String INQ_STA_DT) {
-        this.INQ_STA_DT = INQ_STA_DT;
-    }
-
-    public String getINQ_END_DT() {
-        return INQ_END_DT;
-    }
-
-    public void setINQ_END_DT(String INQ_END_DT) {
-        this.INQ_END_DT = INQ_END_DT;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccTransListDataReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccTransListDataReq.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListDataReq implements Serializable {
     private AccTransListHeaderReq dataHeader;
     private AccTransListBodyReq dataBody;
-
-    public AccTransListHeaderReq getDataHeader() {
-        return dataHeader;
-    }
-
-    public void setDataHeader(AccTransListHeaderReq dataHeader) {
-        this.dataHeader = dataHeader;
-    }
-
-    public AccTransListBodyReq getDataBody() {
-        return dataBody;
-    }
-
-    public void setDataBody(AccTransListBodyReq dataBody) {
-        this.dataBody = dataBody;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccTransListHeaderReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/AccTransListHeaderReq.java
@@ -2,6 +2,13 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListHeaderReq implements Serializable {
     private String UTZPE_CNCT_IPAD;
     private String UTZPE_CNCT_MCHR_UNQ_ID;
@@ -11,68 +18,4 @@ public class AccTransListHeaderReq implements Serializable {
     private String UTZ_MCHR_OS_VER_NM;
     private String UTZ_MCHR_MDL_NM;
     private String UTZ_MCHR_APP_VER_NM;
-
-    public String getUTZPE_CNCT_IPAD() {
-        return UTZPE_CNCT_IPAD;
-    }
-
-    public void setUTZPE_CNCT_IPAD(String UTZPE_CNCT_IPAD) {
-        this.UTZPE_CNCT_IPAD = UTZPE_CNCT_IPAD;
-    }
-
-    public String getUTZPE_CNCT_MCHR_UNQ_ID() {
-        return UTZPE_CNCT_MCHR_UNQ_ID;
-    }
-
-    public void setUTZPE_CNCT_MCHR_UNQ_ID(String UTZPE_CNCT_MCHR_UNQ_ID) {
-        this.UTZPE_CNCT_MCHR_UNQ_ID = UTZPE_CNCT_MCHR_UNQ_ID;
-    }
-
-    public String getUTZPE_CNCT_TEL_NO_TXT() {
-        return UTZPE_CNCT_TEL_NO_TXT;
-    }
-
-    public void setUTZPE_CNCT_TEL_NO_TXT(String UTZPE_CNCT_TEL_NO_TXT) {
-        this.UTZPE_CNCT_TEL_NO_TXT = UTZPE_CNCT_TEL_NO_TXT;
-    }
-
-    public String getUTZPE_CNCT_MCHR_IDF_SRNO() {
-        return UTZPE_CNCT_MCHR_IDF_SRNO;
-    }
-
-    public void setUTZPE_CNCT_MCHR_IDF_SRNO(String UTZPE_CNCT_MCHR_IDF_SRNO) {
-        this.UTZPE_CNCT_MCHR_IDF_SRNO = UTZPE_CNCT_MCHR_IDF_SRNO;
-    }
-
-    public String getUTZ_MCHR_OS_DSCD() {
-        return UTZ_MCHR_OS_DSCD;
-    }
-
-    public void setUTZ_MCHR_OS_DSCD(String UTZ_MCHR_OS_DSCD) {
-        this.UTZ_MCHR_OS_DSCD = UTZ_MCHR_OS_DSCD;
-    }
-
-    public String getUTZ_MCHR_OS_VER_NM() {
-        return UTZ_MCHR_OS_VER_NM;
-    }
-
-    public void setUTZ_MCHR_OS_VER_NM(String UTZ_MCHR_OS_VER_NM) {
-        this.UTZ_MCHR_OS_VER_NM = UTZ_MCHR_OS_VER_NM;
-    }
-
-    public String getUTZ_MCHR_MDL_NM() {
-        return UTZ_MCHR_MDL_NM;
-    }
-
-    public void setUTZ_MCHR_MDL_NM(String UTZ_MCHR_MDL_NM) {
-        this.UTZ_MCHR_MDL_NM = UTZ_MCHR_MDL_NM;
-    }
-
-    public String getUTZ_MCHR_APP_VER_NM() {
-        return UTZ_MCHR_APP_VER_NM;
-    }
-
-    public void setUTZ_MCHR_APP_VER_NM(String UTZ_MCHR_APP_VER_NM) {
-        this.UTZ_MCHR_APP_VER_NM = UTZ_MCHR_APP_VER_NM;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/IndivAllAccInfoDataReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/IndivAllAccInfoDataReq.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class IndivAllAccInfoDataReq implements Serializable {
     private IndivAllAccInfoHeaderReq dataHeader;
     private IndivAllAccInfoBodyReq dataBody;
-
-    public IndivAllAccInfoHeaderReq getDataHeader() {
-        return dataHeader;
-    }
-
-    public void setDataHeader(IndivAllAccInfoHeaderReq dataHeader) {
-        this.dataHeader = dataHeader;
-    }
-
-    public IndivAllAccInfoBodyReq getDataBody() {
-        return dataBody;
-    }
-
-    public void setDataBody(IndivAllAccInfoBodyReq dataBody) {
-        this.dataBody = dataBody;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/IndivAllAccInfoHeaderReq.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/RequestEntity/IndivAllAccInfoHeaderReq.java
@@ -2,6 +2,13 @@ package kr.co.itmsg.woori.RequestEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class IndivAllAccInfoHeaderReq implements Serializable {
     private String UTZPE_CNCT_IPAD;
     private String UTZPE_CNCT_MCHR_UNQ_ID;
@@ -11,68 +18,4 @@ public class IndivAllAccInfoHeaderReq implements Serializable {
     private String UTZ_MCHR_OS_VER_NM;
     private String UTZ_MCHR_MDL_NM;
     private String UTZ_MCHR_APP_VER_NM;
-
-    public String getUTZPE_CNCT_IPAD() {
-        return UTZPE_CNCT_IPAD;
-    }
-
-    public void setUTZPE_CNCT_IPAD(String UTZPE_CNCT_IPAD) {
-        this.UTZPE_CNCT_IPAD = UTZPE_CNCT_IPAD;
-    }
-
-    public String getUTZPE_CNCT_MCHR_UNQ_ID() {
-        return UTZPE_CNCT_MCHR_UNQ_ID;
-    }
-
-    public void setUTZPE_CNCT_MCHR_UNQ_ID(String UTZPE_CNCT_MCHR_UNQ_ID) {
-        this.UTZPE_CNCT_MCHR_UNQ_ID = UTZPE_CNCT_MCHR_UNQ_ID;
-    }
-
-    public String getUTZPE_CNCT_TEL_NO_TXT() {
-        return UTZPE_CNCT_TEL_NO_TXT;
-    }
-
-    public void setUTZPE_CNCT_TEL_NO_TXT(String UTZPE_CNCT_TEL_NO_TXT) {
-        this.UTZPE_CNCT_TEL_NO_TXT = UTZPE_CNCT_TEL_NO_TXT;
-    }
-
-    public String getUTZPE_CNCT_MCHR_IDF_SRNO() {
-        return UTZPE_CNCT_MCHR_IDF_SRNO;
-    }
-
-    public void setUTZPE_CNCT_MCHR_IDF_SRNO(String UTZPE_CNCT_MCHR_IDF_SRNO) {
-        this.UTZPE_CNCT_MCHR_IDF_SRNO = UTZPE_CNCT_MCHR_IDF_SRNO;
-    }
-
-    public String getUTZ_MCHR_OS_DSCD() {
-        return UTZ_MCHR_OS_DSCD;
-    }
-
-    public void setUTZ_MCHR_OS_DSCD(String UTZ_MCHR_OS_DSCD) {
-        this.UTZ_MCHR_OS_DSCD = UTZ_MCHR_OS_DSCD;
-    }
-
-    public String getUTZ_MCHR_OS_VER_NM() {
-        return UTZ_MCHR_OS_VER_NM;
-    }
-
-    public void setUTZ_MCHR_OS_VER_NM(String UTZ_MCHR_OS_VER_NM) {
-        this.UTZ_MCHR_OS_VER_NM = UTZ_MCHR_OS_VER_NM;
-    }
-
-    public String getUTZ_MCHR_MDL_NM() {
-        return UTZ_MCHR_MDL_NM;
-    }
-
-    public void setUTZ_MCHR_MDL_NM(String UTZ_MCHR_MDL_NM) {
-        this.UTZ_MCHR_MDL_NM = UTZ_MCHR_MDL_NM;
-    }
-
-    public String getUTZ_MCHR_APP_VER_NM() {
-        return UTZ_MCHR_APP_VER_NM;
-    }
-
-    public void setUTZ_MCHR_APP_VER_NM(String UTZ_MCHR_APP_VER_NM) {
-        this.UTZ_MCHR_APP_VER_NM = UTZ_MCHR_APP_VER_NM;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccBasicInfoBody.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccBasicInfoBody.java
@@ -2,6 +2,13 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccBasicInfoBody implements Serializable {
     private String ACNO;
     private String ACT_STS;
@@ -18,124 +25,4 @@ public class AccBasicInfoBody implements Serializable {
     private String SMPL_PRFT_RT;
     private String CT_ATCNT_BAL;
     private String LST_LN_PCS_AM;
-
-    public String getACNO() {
-        return ACNO;
-    }
-
-    public void setACNO(String ACNO) {
-        this.ACNO = ACNO;
-    }
-
-    public String getACT_STS() {
-        return ACT_STS;
-    }
-
-    public void setACT_STS(String ACT_STS) {
-        this.ACT_STS = ACT_STS;
-    }
-
-    public String getCUCD() {
-        return CUCD;
-    }
-
-    public void setCUCD(String CUCD) {
-        this.CUCD = CUCD;
-    }
-
-    public String getPDCD() {
-        return PDCD;
-    }
-
-    public void setPDCD(String PDCD) {
-        this.PDCD = PDCD;
-    }
-
-    public String getCT_BAL() {
-        return CT_BAL;
-    }
-
-    public void setCT_BAL(String CT_BAL) {
-        this.CT_BAL = CT_BAL;
-    }
-
-    public String getNEW_DT() {
-        return NEW_DT;
-    }
-
-    public void setNEW_DT(String NEW_DT) {
-        this.NEW_DT = NEW_DT;
-    }
-
-    public String getXPR_DT() {
-        return XPR_DT;
-    }
-
-    public void setXPR_DT(String XPR_DT) {
-        this.XPR_DT = XPR_DT;
-    }
-
-    public String getTXPR_PDCD() {
-        return TXPR_PDCD;
-    }
-
-    public void setTXPR_PDCD(String TXPR_PDCD) {
-        this.TXPR_PDCD = TXPR_PDCD;
-    }
-
-    public String getMM_PID_AM() {
-        return MM_PID_AM;
-    }
-
-    public void setMM_PID_AM(String MM_PID_AM) {
-        this.MM_PID_AM = MM_PID_AM;
-    }
-
-    public String getTDY_BSPR() {
-        return TDY_BSPR;
-    }
-
-    public void setTDY_BSPR(String TDY_BSPR) {
-        this.TDY_BSPR = TDY_BSPR;
-    }
-
-    public String getTDY_EVL_AM() {
-        return TDY_EVL_AM;
-    }
-
-    public void setTDY_EVL_AM(String TDY_EVL_AM) {
-        this.TDY_EVL_AM = TDY_EVL_AM;
-    }
-
-    public String getIVST_PRN() {
-        return IVST_PRN;
-    }
-
-    public void setIVST_PRN(String IVST_PRN) {
-        this.IVST_PRN = IVST_PRN;
-    }
-
-    public String getSMPL_PRFT_RT() {
-        return SMPL_PRFT_RT;
-    }
-
-    public void setSMPL_PRFT_RT(String SMPL_PRFT_RT) {
-        this.SMPL_PRFT_RT = SMPL_PRFT_RT;
-    }
-
-    public String getCT_ATCNT_BAL() {
-        return CT_ATCNT_BAL;
-    }
-
-    public void setCT_ATCNT_BAL(String CT_ATCNT_BAL) {
-        this.CT_ATCNT_BAL = CT_ATCNT_BAL;
-    }
-
-    public String getLST_LN_PCS_AM() {
-        return LST_LN_PCS_AM;
-    }
-
-    public void setLST_LN_PCS_AM(String LST_LN_PCS_AM) {
-        this.LST_LN_PCS_AM = LST_LN_PCS_AM;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccBasicInfoData.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccBasicInfoData.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccBasicInfoData implements Serializable {
     private AccBasicInfoHeader dataHeader;
     private AccBasicInfoBody dataBody;
-
-    public AccBasicInfoHeader getDataHeader() {
-        return dataHeader;
-    }
-
-    public void setDataHeader(AccBasicInfoHeader dataHeader) {
-        this.dataHeader = dataHeader;
-    }
-
-    public AccBasicInfoBody getDataBody() {
-        return dataBody;
-    }
-
-    public void setDataBody(AccBasicInfoBody dataBody) {
-        this.dataBody = dataBody;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccBasicInfoHeader.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccBasicInfoHeader.java
@@ -2,14 +2,13 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccBasicInfoHeader implements Serializable {
     private String GLBL_ID;
-
-    public String getGLBL_ID() {
-        return GLBL_ID;
-    }
-
-    public void setGLBL_ID(String GLBL_ID) {
-        this.GLBL_ID = GLBL_ID;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListBody.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListBody.java
@@ -3,23 +3,14 @@ package kr.co.itmsg.woori.ResponseEntity;
 import java.io.Serializable;
 import java.util.ArrayList;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListBody implements Serializable {
     private int GRID_CNT;
     private ArrayList<AccTransListBodyGRID> GRID;
-
-    public int getGRID_CNT() {
-        return GRID_CNT;
-    }
-
-    public void setGRID_CNT(int GRID_CNT) {
-        this.GRID_CNT = GRID_CNT;
-    }
-
-    public ArrayList<AccTransListBodyGRID> getGRID() {
-        return GRID;
-    }
-
-    public void setGRID(ArrayList<AccTransListBodyGRID> GRID) {
-        this.GRID = GRID;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListBodyGRID.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListBodyGRID.java
@@ -2,6 +2,13 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListBodyGRID implements Serializable {
     private String TRN_DT;
     private String TRN_TM;
@@ -16,108 +23,4 @@ public class AccTransListBodyGRID implements Serializable {
     private String RQSPE_NM;
     private String PID_SQ;
     private String TRN_STCD;
-
-    public String getTRN_DT() {
-        return TRN_DT;
-    }
-
-    public void setTRN_DT(String TRN_DT) {
-        this.TRN_DT = TRN_DT;
-    }
-
-    public String getTRN_TM() {
-        return TRN_TM;
-    }
-
-    public void setTRN_TM(String TRN_TM) {
-        this.TRN_TM = TRN_TM;
-    }
-
-    public String getCUCD() {
-        return CUCD;
-    }
-
-    public void setCUCD(String CUCD) {
-        this.CUCD = CUCD;
-    }
-
-    public String getPBOK_PRNG_OTLN_CD() {
-        return PBOK_PRNG_OTLN_CD;
-    }
-
-    public void setPBOK_PRNG_OTLN_CD(String PBOK_PRNG_OTLN_CD) {
-        this.PBOK_PRNG_OTLN_CD = PBOK_PRNG_OTLN_CD;
-    }
-
-    public String getDPS_RAP_KDCD() {
-        return DPS_RAP_KDCD;
-    }
-
-    public void setDPS_RAP_KDCD(String DPS_RAP_KDCD) {
-        this.DPS_RAP_KDCD = DPS_RAP_KDCD;
-    }
-
-    public String getMD_KDCD() {
-        return MD_KDCD;
-    }
-
-    public void setMD_KDCD(String MD_KDCD) {
-        this.MD_KDCD = MD_KDCD;
-    }
-
-    public String getRCV_AM() {
-        return RCV_AM;
-    }
-
-    public void setRCV_AM(String RCV_AM) {
-        this.RCV_AM = RCV_AM;
-    }
-
-    public String getPAY_AM() {
-        return PAY_AM;
-    }
-
-    public void setPAY_AM(String PAY_AM) {
-        this.PAY_AM = PAY_AM;
-    }
-
-    public String getDPS_BAL() {
-        return DPS_BAL;
-    }
-
-    public void setDPS_BAL(String DPS_BAL) {
-        this.DPS_BAL = DPS_BAL;
-    }
-
-    public String getTRN_TXT() {
-        return TRN_TXT;
-    }
-
-    public void setTRN_TXT(String TRN_TXT) {
-        this.TRN_TXT = TRN_TXT;
-    }
-
-    public String getRQSPE_NM() {
-        return RQSPE_NM;
-    }
-
-    public void setRQSPE_NM(String RQSPE_NM) {
-        this.RQSPE_NM = RQSPE_NM;
-    }
-
-    public String getPID_SQ() {
-        return PID_SQ;
-    }
-
-    public void setPID_SQ(String PID_SQ) {
-        this.PID_SQ = PID_SQ;
-    }
-
-    public String getTRN_STCD() {
-        return TRN_STCD;
-    }
-
-    public void setTRN_STCD(String TRN_STCD) {
-        this.TRN_STCD = TRN_STCD;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListData.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListData.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListData implements Serializable {
     private AccTransListHeader dataHeader;
     private AccTransListBody dataBody;
-
-    public AccTransListHeader getDataHeader() {
-        return dataHeader;
-    }
-
-    public void setDataHeader(AccTransListHeader dataHeader) {
-        this.dataHeader = dataHeader;
-    }
-
-    public AccTransListBody getDataBody() {
-        return dataBody;
-    }
-
-    public void setDataBody(AccTransListBody dataBody) {
-        this.dataBody = dataBody;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListHeader.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/AccTransListHeader.java
@@ -2,14 +2,13 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class AccTransListHeader implements Serializable {
     private String GLBL_ID;
-
-    public String getGLBL_ID() {
-        return GLBL_ID;
-    }
-
-    public void setGLBL_ID(String GLBL_ID) {
-        this.GLBL_ID = GLBL_ID;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoBody.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoBody.java
@@ -3,23 +3,14 @@ package kr.co.itmsg.woori.ResponseEntity;
 import java.io.Serializable;
 import java.util.ArrayList;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class IndivAllAccInfoBody implements Serializable {
     private String GRID_CNT;
     private ArrayList<IndivAllAccInfoBodyGRID> GRID;
-
-    public String getGRID_CNT() {
-        return GRID_CNT;
-    }
-
-    public void setGRID_CNT(String GRID_CNT) {
-        this.GRID_CNT = GRID_CNT;
-    }
-
-    public ArrayList<IndivAllAccInfoBodyGRID> getGRID() {
-        return GRID;
-    }
-
-    public void setGRID(ArrayList<IndivAllAccInfoBodyGRID> GRID) {
-        this.GRID = GRID;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoBodyGRID.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoBodyGRID.java
@@ -2,6 +2,13 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class IndivAllAccInfoBodyGRID implements Serializable {
     private String ACNO;
     private String PDCD;
@@ -14,94 +21,6 @@ public class IndivAllAccInfoBodyGRID implements Serializable {
     private String XPR_DT;
     private String ADNT_RGS_YN;
     private String ACCT_KND;
-
-    public String getACNO() {
-        return ACNO;
-    }
-
-    public void setACNO(String ACNO) {
-        this.ACNO = ACNO;
-    }
-
-    public String getPDCD() {
-        return PDCD;
-    }
-
-    public void setPDCD(String PDCD) {
-        this.PDCD = PDCD;
-    }
-
-    public String getPRD_NM() {
-        return PRD_NM;
-    }
-
-    public void setPRD_NM(String PRD_NM) {
-        this.PRD_NM = PRD_NM;
-    }
-
-    public String getCUCD() {
-        return CUCD;
-    }
-
-    public void setCUCD(String CUCD) {
-        this.CUCD = CUCD;
-    }
-
-    public String getPDOK_BAL() {
-        return PDOK_BAL;
-    }
-
-    public void setPDOK_BAL(String PDOK_BAL) {
-        this.PDOK_BAL = PDOK_BAL;
-    }
-
-    public String getWDR_AVL_AM() {
-        return WDR_AVL_AM;
-    }
-
-    public void setWDR_AVL_AM(String WDR_AVL_AM) {
-        this.WDR_AVL_AM = WDR_AVL_AM;
-    }
-
-    public String getNEW_DT() {
-        return NEW_DT;
-    }
-
-    public void setNEW_DT(String NEW_DT) {
-        this.NEW_DT = NEW_DT;
-    }
-
-    public String getLST_TRN_DT() {
-        return LST_TRN_DT;
-    }
-
-    public void setLST_TRN_DT(String LST_TRN_DT) {
-        this.LST_TRN_DT = LST_TRN_DT;
-    }
-
-    public String getXPR_DT() {
-        return XPR_DT;
-    }
-
-    public void setXPR_DT(String XPR_DT) {
-        this.XPR_DT = XPR_DT;
-    }
-
-    public String getADNT_RGS_YN() {
-        return ADNT_RGS_YN;
-    }
-
-    public void setADNT_RGS_YN(String ADNT_RGS_YN) {
-        this.ADNT_RGS_YN = ADNT_RGS_YN;
-    }
-
-    public String getACCT_KND() {
-        return ACCT_KND;
-    }
-
-    public void setACCT_KND(String ACCT_KND) {
-        this.ACCT_KND = ACCT_KND;
-    }
 }
 
 

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoData.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoData.java
@@ -2,23 +2,14 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class IndivAllAccInfoData implements Serializable {
     private IndivAllAccInfoHeader dataHeader;
     private IndivAllAccInfoBody dataBody;
-
-    public IndivAllAccInfoHeader getDataHeader() {
-        return dataHeader;
-    }
-
-    public void setDataHeader(IndivAllAccInfoHeader dataHeader) {
-        this.dataHeader = dataHeader;
-    }
-
-    public IndivAllAccInfoBody getDataBody() {
-        return dataBody;
-    }
-
-    public void setDataBody(IndivAllAccInfoBody dataBody) {
-        this.dataBody = dataBody;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoHeader.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/ResponseEntity/IndivAllAccInfoHeader.java
@@ -2,14 +2,13 @@ package kr.co.itmsg.woori.ResponseEntity;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class IndivAllAccInfoHeader implements Serializable {
     private String GLBL_ID;
-
-    public String getGLBL_ID() {
-        return GLBL_ID;
-    }
-
-    public void setGLBL_ID(String GLBL_ID) {
-        this.GLBL_ID = GLBL_ID;
-    }
 }

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/view/AccBasicInfoActivity.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/view/AccBasicInfoActivity.java
@@ -169,19 +169,18 @@ public class AccBasicInfoActivity extends AppCompatActivity {
                     }
                 }
                 catch (Exception e) {
-                    ErrorNotify(s + "\n" + e.getMessage());
+                    errorNotify(s + "\n" + e.getMessage());
                 }
             }
             else {
-                ErrorNotify(s);
+                errorNotify(s);
             }
         }
     }
 
 
 
-    private void ErrorNotify(String errorMessage)
-    {
+    private void errorNotify(String errorMessage) {
         String title = "통신장애";
         String message = "통신이 월활하지 않습니다. 다시 시도하여 주세요.";
 

--- a/Android_example/app/src/main/java/kr/co/itmsg/woori/view/AccTransListActivity.java
+++ b/Android_example/app/src/main/java/kr/co/itmsg/woori/view/AccTransListActivity.java
@@ -131,11 +131,11 @@ public class AccTransListActivity extends AppCompatActivity {
                     }
                 }
                 catch (Exception e) {
-                    ErrorNotify(s + "\n" + e.getMessage());
+                    errorNotify(s + "\n" + e.getMessage());
                 }
             }
             else {
-                ErrorNotify(s);
+                errorNotify(s);
             }
         }
     }
@@ -205,8 +205,7 @@ public class AccTransListActivity extends AppCompatActivity {
         }
     }
 
-    private void ErrorNotify(String errorMessage)
-    {
+    private void errorNotify(String errorMessage) {
         String title = "통신장애";
         String message = "통신이 월활하지 않습니다. 다시 시도하여 주세요.";
 


### PR DESCRIPTION
## 변경 사항 및 이슈
`ErrorNotify` 메서드를 자바 컨벤션에 맞게 수정하였고, VO 객체에 Lombok을 적용하였습니다.

## PR Point
- `ErrorNotify` 메서드 이름 변경 및 중괄호 위치 수정
- `XXXEntity` 패키지의 VO 객체들에 Lombok 적용 후 getter, setter 제거
- `build.gradle` 에 lombok 1.18.8 버전 dependency 추가

## 참고사항
- Kotlin 으로의 전환을 염두에 두고 계서서 Lombok을 일부러 쓰시지 않으셨다면 해당 커밋은 제외처리 하겠습니다
